### PR TITLE
refactor: use `@std/tar`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@polyseam/inflate-response",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "exports": "./mod.ts",
   "tasks": {
     "dev": "deno run --watch main.ts",

--- a/deno.json
+++ b/deno.json
@@ -11,10 +11,9 @@
     ".github"
   ],
   "imports": {
-    "@std/archive": "jsr:@std/archive@0.214.0",
     "@std/assert": "jsr:@std/assert@^0.221.0",
     "@std/fs": "jsr:@std/fs@0.214.0",
-    "@std/io": "jsr:@std/io@0.214.0",
-    "@std/path": "jsr:@std/path@0.214.0"
+    "@std/path": "jsr:@std/path@0.214.0",
+    "@std/tar": "jsr:@std/tar@^0.1.1"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -2,24 +2,16 @@
   "version": "3",
   "packages": {
     "specifiers": {
-      "jsr:@std/archive@0.214.0": "jsr:@std/archive@0.214.0",
       "jsr:@std/assert@^0.214.0": "jsr:@std/assert@0.214.0",
       "jsr:@std/assert@^0.221.0": "jsr:@std/assert@0.221.0",
-      "jsr:@std/bytes@^0.214.0": "jsr:@std/bytes@0.214.0",
       "jsr:@std/fmt@^0.221.0": "jsr:@std/fmt@0.221.0",
       "jsr:@std/fs@0.214.0": "jsr:@std/fs@0.214.0",
-      "jsr:@std/io@0.214.0": "jsr:@std/io@0.214.0",
-      "jsr:@std/io@^0.214.0": "jsr:@std/io@0.214.0",
       "jsr:@std/path@0.214.0": "jsr:@std/path@0.214.0",
-      "jsr:@std/path@^0.214.0": "jsr:@std/path@0.214.0"
+      "jsr:@std/path@^0.214.0": "jsr:@std/path@0.214.0",
+      "jsr:@std/streams@^1.0.5": "jsr:@std/streams@1.0.5",
+      "jsr:@std/tar@^0.1.1": "jsr:@std/tar@0.1.1"
     },
     "jsr": {
-      "@std/archive@0.214.0": {
-        "integrity": "298d3f1f820cac72dfbc4a716e058655758015385ad116a247b9605c7103d89f",
-        "dependencies": [
-          "jsr:@std/io@^0.214.0"
-        ]
-      },
       "@std/assert@0.214.0": {
         "integrity": "55d398de76a9828fd3b1aa653f4dba3eee4c6985d90c514865d2be9bd082b140"
       },
@@ -29,28 +21,29 @@
           "jsr:@std/fmt@^0.221.0"
         ]
       },
-      "@std/bytes@0.214.0": {
-        "integrity": "eba2a06824fd22b9cb1214c53988ad57431177497e6198ba0ff8ab207dae996f"
-      },
       "@std/fmt@0.221.0": {
         "integrity": "379fed69bdd9731110f26b9085aeb740606b20428ce6af31ef6bd45ef8efa62a"
       },
       "@std/fs@0.214.0": {
         "integrity": "bc880fea0be120cb1550b1ed7faf92fe071003d83f2456a1e129b39193d85bea",
         "dependencies": [
+          "jsr:@std/assert@^0.214.0",
           "jsr:@std/path@^0.214.0"
-        ]
-      },
-      "@std/io@0.214.0": {
-        "integrity": "81563289d48830f966a5c607841fb5b7048874e0368f873d6148776de0a1e890",
-        "dependencies": [
-          "jsr:@std/bytes@^0.214.0"
         ]
       },
       "@std/path@0.214.0": {
         "integrity": "d5577c0b8d66f7e8e3586d864ebdf178bb326145a3611da5a51c961740300285",
         "dependencies": [
           "jsr:@std/assert@^0.214.0"
+        ]
+      },
+      "@std/streams@1.0.5": {
+        "integrity": "74e5c73d7d68eeab0d7fba3b05cbee3ba4ac5ae37c5f4e675f67e62f8f53edc4"
+      },
+      "@std/tar@0.1.1": {
+        "integrity": "ae7dbe0765ba67f2f8335338d86293bd3605a54f037357b1969d86714f4a9ee9",
+        "dependencies": [
+          "jsr:@std/streams@^1.0.5"
         ]
       }
     }
@@ -164,11 +157,10 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@std/archive@0.214.0",
       "jsr:@std/assert@^0.221.0",
       "jsr:@std/fs@0.214.0",
-      "jsr:@std/io@0.214.0",
-      "jsr:@std/path@0.214.0"
+      "jsr:@std/path@0.214.0",
+      "jsr:@std/tar@^0.1.1"
     ]
   }
 }


### PR DESCRIPTION
a friendly pal working on the @std/ project made a PR to bring us into the future using `@std/tar`

this branch integrates and validates those updates in preparation for merge and release